### PR TITLE
Using shutil.move rather than os.rename

### DIFF
--- a/dir2ogg
+++ b/dir2ogg
@@ -34,6 +34,7 @@ Scratch tags using the filename will be written for wav files (and mp3s with no 
 import locale
 import sys
 import os, os.path
+import shutil
 import re
 import warnings
 from fnmatch import _cache, translate
@@ -395,7 +396,7 @@ class Convert(Id3TagHandler):
             if self.decoder == 'mplayer':
                 # Move the file for mplayer (which uses tempwav), so it works
                 # for --preserve-wav.
-                os.rename(tempwav, self.songwav)
+                shutil.move(tempwav, self.songwav)
             if retcode != 0:
                 return (False, None)
             else:


### PR DESCRIPTION
See issue #4 , this PR is implementing the provided patch...